### PR TITLE
change to Music Industry Blog link from Science Amercian

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ﻿# Open Music Recommendation System (Open MRS) by BerryAI
-Acai is an open source project initialised by Berry Labs, a startup working towards machine learning algorithms to solve daily issues. Acai (codename) is trying to solve the problem of <a href="http://www.scientificamerican.com/article/the-tyranny-of-choice-2004-04/">The Tyranny of Choice</a> (a.k.a Paradox of Choice) to describe the misery of users facing over-abundant choices. In the music area, especially in the age of streaming music, this paradox becomes so significant that it affects every single piece of choice when users try to enjoy music. It's why this project was born.
+Acai is an open source project initialised by Berry Labs, a startup working towards machine learning algorithms to solve daily issues. Acai (codename) is trying to solve the problem of <a href="https://musicindustryblog.wordpress.com/tag/tyranny-of-choice/">The Tyranny of Choice</a> (a.k.a Paradox of Choice) to describe the misery of users facing over-abundant choices. In the music area, especially in the age of streaming music, this paradox becomes so significant that it affects every single piece of choice when users try to enjoy music. It's why this project was born.
 http://www.acai.berry.ai/
 
 ## Getting Started
@@ -39,7 +39,7 @@ https://www.continuum.io/downloads
 and find the proper install packages
 
 #### Torch
-You can find torch installation instruction in the official site: 
+You can find torch installation instruction in the official site:
 http://torch.ch/
 You can also refer to our wiki page:
 https://github.com/BerryAI/music_cortex/wiki/Torch-Setup


### PR DESCRIPTION
The original link, reported by @fzqneo, it's behind pay-wall, so I changed it to Music Industry blog, which explains the issue in music in more details. 
